### PR TITLE
Update Venue#model_route

### DIFF
--- a/lib/eventbrite/api/model/venue.rb
+++ b/lib/eventbrite/api/model/venue.rb
@@ -3,7 +3,7 @@ module Eventbrite
     module Model
       class Venue < Base
       	def model_route
-          'users/:user_id/venues'
+          'organizations/:organization_id/venues'
         end
       end
     end


### PR DESCRIPTION
Replacing with: `organizations/:organization_id/venues` as `users/:user_id/venues` is deprecated.